### PR TITLE
ONAを含むように変更・前期の2期を含めるチェックボックスを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
         <option value="SUMMER">Summer</option>
         <option value="FALL">Fall</option>
     </select>
+
+    <button id="fetchButton">Fetch Anime</button>
+    <p>
+        <input type="checkbox" id="include-previous-season">
+        <label for="include-before-season">Include two-cour anime from the previous season</label>
+    </p>
     <!-- 次バージョン用、一旦コメントアウト -->
     <!-- <label for="format">Format: </label>
     <select id="format">
@@ -36,7 +42,6 @@
         <option value="Music">Music</option>
     </select> -->
 
-    <button id="fetchButton">Fetch Anime</button>
 
     <div class="tier-list">
     </div>


### PR DESCRIPTION
ONAが含まれていなかったため検索にひっかからないケースがあったため含めるように変更
現在視聴中という意味で前期の2クールアニメを含めるかを選択するチェックボックスを追加
ONAを含めたことによりショートアニメが含まれたのでアニメ1話あたりの長さを取得して除外
稀にdurationがnullの時があるのでnullの場合は含めるようにした